### PR TITLE
Fixed recipe collision between butter and cheese

### DIFF
--- a/src/main/resources/data/farmerscroptopia/recipes/croptopia_cooking/cheese.json
+++ b/src/main/resources/data/farmerscroptopia/recipes/croptopia_cooking/cheese.json
@@ -7,7 +7,7 @@
       "tag": "forge:milks"
     },
     {
-      "tag": "forge:salts"
+      "tag": "forge:milks"
     }
   ],
   "result": {


### PR DESCRIPTION
Hi, I don't know anything about coding, but I like your mod and noticed that I wasn't able to make butter. I changed the cheese recipe from milk and salt to milk and milk so that it no longer overlaps with the recipe for butter.